### PR TITLE
Specify utf-8 encoding

### DIFF
--- a/nrc_exporter.py
+++ b/nrc_exporter.py
@@ -496,7 +496,7 @@ def save_gpx(gpx_data, activity_id):
     """
 
     file_path = os.path.join(GPX_FOLDER, activity_id + ".gpx")
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         f.write(gpx_data)
 
 


### PR DESCRIPTION
Fix `UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f384' in position 414: character maps to <undefined>`.
This PR resolves the UnicodeEncodeError that occurs on activities parsing in function save_gpx.