### PR TITLE
Fix dead `unite.nike.com` login URL and crash in manual-token path

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,7 @@ Nike uses Akamai Bot Manager which doesn't allow scripts to automatically log us
 
 ### From local storage
 
-Open up your favorite browser, open developer tools, and head over to this [login url on the main page](https://accounts.nike.com/lookup?client_id=4fd2d5e7db76e0f85a6bb56721bd51df&redirect_uri=https://www.nike.com/auth/login&response_type=code&scope=openid%20nike.digital%20profile%20email%20phone%20flow%20country&state=9cda65dea2c240cb81ed583bf733c122&code_challenge=WbnqwTvTmE-O4jVtcs4GYKvr0dhFgppcM2Hrl1qEEiU&code_challenge_method=S256) and log in.
-
-Submitting the form will not do much. You will just have a blank page in front of you but you will be logged in. Now in order to extract the access tokens, open up developer tools. You can search online about how to open the developer tools for your specific browser. Once the developer tools are open, click on the `Console` and type this:
+Open up [https://www.nike.com/](https://www.nike.com/) in your browser and log in. To extract the access token, open up developer tools. You can search online about how to open the developer tools for your specific browser. Once the developer tools are open, click on the `Console` and type this:
 
 ```
 JSON.parse(window.localStorage.getItem('oidc.user:https://accounts.nike.com:4fd2d5e7db76e0f85a6bb56721bd51df')).access_token
@@ -178,7 +176,7 @@ This should print your access tokens on screen. If this doesn't work and/or give
 
 ### From network tab
 
-If the local storage doesn't contain any access tokens, open up your favorite browser, *open developer tools*, and head over to this [alternate login url](https://unite.nike.com/s3/unite/mobile.html?androidSDKVersion=3.1.0&corsoverride=https://unite.nike.com&uxid=com.nike.sport.running.droid.3.8&locale=en_US&backendEnvironment=identity&view=login&clientId=WLr1eIG5JSNNcBJM3npVa6L76MK8OBTt&facebookAppId=84697719333&wechatAppId=wxde7d0246cfaf32f7) and log in.
+If the local storage doesn't contain any access tokens, open up [https://www.nike.com/](https://www.nike.com/) in your browser, *open developer tools*, and log in.
 
 Then go to the "network" tab in the developer tools. A couple of requests should be visible there assuming you logged in after opening the developer tools:
 

--- a/nrc_exporter.py
+++ b/nrc_exporter.py
@@ -231,6 +231,7 @@ def get_access_token(options):
     """
 
     login_success = False
+    driver = None
 
     if options["gecko_path"] and not options["manual"]:
         info(f"🚗 Starting gecko webdriver")
@@ -268,10 +269,11 @@ def get_access_token(options):
             )
             sys.exit(1)
 
-    info(
-        f"Closing the webdriver. From here on we will be using requests library instead"
-    )
-    driver.quit()
+    if driver is not None:
+        info(
+            f"Closing the webdriver. From here on we will be using requests library instead"
+        )
+        driver.quit()
     return access_token
 
 

--- a/nrc_exporter.py
+++ b/nrc_exporter.py
@@ -32,13 +32,7 @@ __license__ = "MIT"
 ACTIVITY_FOLDER = os.path.join(os.getcwd(), "activities")
 GPX_FOLDER = os.path.join(os.getcwd(), "gpx_output")
 LOGIN_URL = "https://www.nike.com/in/launch?s=in-stock"
-MOBILE_LOGIN_URL = (
-    "https://unite.nike.com/s3/unite/mobile.html?androidSDKVersion=3.1.0"
-    "&corsoverride=https://unite.nike.com&uxid=com.nike.sport.running.droid.3.8"
-    "&locale=en_US&backendEnvironment=identity&view=login"
-    "&clientId=WLr1eIG5JSNNcBJM3npVa6L76MK8OBTt&facebookAppId=84697719333"
-    "&wechatAppId=wxde7d0246cfaf32f7"
-)
+MOBILE_LOGIN_URL = "https://www.nike.com/"
 ACTIVITY_LIST_URL = "https://api.nike.com/plus/v3/activities/before_id/v3/*?limit=30&types=run%2Cjogging&include_deleted=false"
 ACTIVITY_LIST_PAGINATION = (
     "https://api.nike.com/plus/v3/activities/before_id/v3/{before_id}?limit=30&types=run%2Cjogging&include_deleted=false"


### PR DESCRIPTION
## Summary
- The `unite.nike.com` mobile login URL referenced in the script and README no longer resolves. Point users to `https://www.nike.com/` instead, which is where the `oidc.user:...` entry gets populated on login
- Fix `UnboundLocalError: local variable 'driver' referenced before assignment` which was running unconditionally when geckodriver was missing

## Test plan
- [x] `python nrc_exporter.py -t <token>` (token grabbed via the new README flow) downloads activities
- [x] `python nrc_exporter.py -e ... -p ...` without geckodriver installed: prompts for token, accepts it, no longer crashes on cleanup
